### PR TITLE
X axis ticks only painted for number of selected x values

### DIFF
--- a/src/Chart.Core.js
+++ b/src/Chart.Core.js
@@ -1591,11 +1591,13 @@
 
 
 					// Small lines at the bottom of the base grid line
-					ctx.beginPath();
-					ctx.moveTo(linePos,this.endPoint);
-					ctx.lineTo(linePos,this.endPoint + 5);
-					ctx.stroke();
-					ctx.closePath();
+			                if(index % this.xLabelsSkipper === 0) {
+			                        ctx.beginPath();
+			                        ctx.moveTo(linePos,this.endPoint);
+			                        ctx.lineTo(linePos,this.endPoint + 5);
+			                        ctx.stroke();
+			                	ctx.closePath();
+			                }
 
 					ctx.save();
 					ctx.translate(xPos,(isRotated) ? this.endPoint + 12 : this.endPoint + 8);


### PR DESCRIPTION
Until now all ticks have been painted which does not makes sense if you have thousands of values and only want to show 10. the svg path for the tick mark is now only painted if the corresponding value is also painted. thanks for your fork!
